### PR TITLE
35 upload tyndale etc data

### DIFF
--- a/app/core/embedding/openai.py
+++ b/app/core/embedding/openai.py
@@ -1,6 +1,6 @@
 '''Implemetations for embedding interface'''
 import os
-from typing import List
+from typing import List, Optional
 import openai
 
 import schema
@@ -17,12 +17,13 @@ class OpenAIEmbedding(EmbeddingInterface):
     api_object = None
     def __init__(self, #pylint: disable=super-init-not-called
                 key:str=os.getenv("OPENAI_API_KEY"),
+                api_key: Optional[str] = os.getenv("OPENAI_API_KEY"), # the set_embedding method uses api_key, so it's accepted here for cross-compatibility
                 model:str = 'text-embedding-ada-002') -> None:
-        '''Sets the API key and initializes library objects if any'''
-        if key is None:
+        '''Sets the API key and initializes library objects if any'''            
+        self.api_key = key if key is not None else api_key
+        if self.api_key is None:
             raise AccessException("OPENAI_API_KEY needs to be provided."+\
                 "Visit https://platform.openai.com/account/api-keys")
-        self.api_key = key
         self.api_object = openai
         self.api_object.api_key = key
         self.model = model

--- a/app/core/file_processor/__init__.py
+++ b/app/core/file_processor/__init__.py
@@ -32,7 +32,6 @@ class FileProcessorInterface:
         with open(file, 'r', encoding="utf-8") as csvfile:
             reader = csv.DictReader(csvfile, delimiter=col_delimiter)
             for row in reader:
-                print(row)
                 if row['links'] is None or row['links'].strip() == "":
                     links = []
                 else:

--- a/app/core/vectordb/__init__.py
+++ b/app/core/vectordb/__init__.py
@@ -31,4 +31,8 @@ class VectordbInterface(ABC):
     def get_available_labels(self) -> List[str]:
         '''Query DB and find out the list of labels available in metadata,
         to be used for later filtering'''
+        
+    def get(self, **kwargs) -> List:
+        '''Return properties of the DB'''
+        return self.db_conn.get(**kwargs)
     

--- a/app/routers.py
+++ b/app/routers.py
@@ -263,10 +263,10 @@ async def upload_sentences(
         embedding_type=schema.EmbeddingType.OPENAI
     if embedding_type:
         data_stack.set_embedding(embedding_type)
-        # This may have to be a background job!!!
+        # FIXME: This may have to be a background job!!!
         data_stack.embedding.get_embeddings(doc_list=document_objs)
 
-    # This may have to be a background job!!!
+    # FIXME: This may have to be a background job!!!
     data_stack.vectordb.add_to_collection(docs=document_objs)
     return {"message": "Documents added to DB"}
 
@@ -305,7 +305,7 @@ async def upload_text_file( #pylint: disable=too-many-arguments
     with open(f"{UPLOAD_PATH}{file_obj.filename}", 'w', encoding='utf-8') as tfp:
         tfp.write(file_obj.file.read().decode("utf-8"))
 
-    # This may have to be a background job!!!
+    # FIXME: This may have to be a background job!!!
     docs = data_stack.file_processor.process_file(
         file=f"{UPLOAD_PATH}{file_obj.filename}",
         file_type=schema.FileType.TEXT,
@@ -314,7 +314,7 @@ async def upload_text_file( #pylint: disable=too-many-arguments
         )
     if embedding_type:
         data_stack.set_embedding(embedding_type)
-        # This may have to be a background job!!!
+        # FIXME: This may have to be a background job!!!
         data_stack.embedding.get_embeddings(doc_list=docs)
     data_stack.vectordb.add_to_collection(docs=docs)
     return {"message": "Documents added to DB"}
@@ -346,14 +346,14 @@ async def upload_csv_file( #pylint: disable=too-many-arguments
     vectordb_args = compose_vector_db_args(vectordb_type, vectordb_config)
     data_stack.set_vectordb(vectordb_type,**vectordb_args)
     if not embedding_type and vectordb_type==schema.DatabaseType.POSTGRES:
-        embedding_type=schema.EmbeddingType.OPENAI
+        embedding_type=schema.EmbeddingType.HUGGINGFACE_DEFAULT
 
     if not os.path.exists(UPLOAD_PATH):
         os.mkdir(UPLOAD_PATH)
     with open(f"{UPLOAD_PATH}{file_obj.filename}", 'w', encoding='utf-8') as tfp:
         tfp.write(file_obj.file.read().decode("utf-8"))
 
-    # This may have to be a background job!!!
+    # FIXME: This may have to be a background job!!!
     if col_delimiter==schema.CsvColDelimiter.COMMA:
         col_delimiter=","
     elif col_delimiter==schema.CsvColDelimiter.TAB:
@@ -365,7 +365,7 @@ async def upload_csv_file( #pylint: disable=too-many-arguments
         )
     if embedding_type:
         data_stack.set_embedding(embedding_type)
-        # This may have to be a background job!!!
+        # FIXME: This may have to be a background job!!!
         data_stack.embedding.get_embeddings(doc_list=docs)
     data_stack.vectordb.add_to_collection(docs=docs)
     return {"message": "Documents added to DB"}

--- a/app/schema.py
+++ b/app/schema.py
@@ -22,6 +22,10 @@ class EmbeddingType(str, Enum):
     '''Available text embedding technology choices'''
     HUGGINGFACE_DEFAULT = "huggingface" # TODO: add support for multiple models ?
     OPENAI = "OpenAI"
+    
+class EmbeddingDimensionSize(str, Enum):
+    OPENAI = 1536
+    HUGGINGFACE_DEFAULT = 384
 
 class DatabaseType(str, Enum):
     '''Available Database type choices'''

--- a/recipes/postgres_local_embeddings.py
+++ b/recipes/postgres_local_embeddings.py
@@ -1,0 +1,61 @@
+'''This script inputs text data into a vector database.
+Content type: text/markdown files
+File processor: Langchain loaders and splitters
+Embedding: Local Sentence Transformers
+Database: Postgres with pgvector extension
+'''
+
+import os
+import glob
+import sys
+
+# Add application directory to system path
+sys.path.append('../app')
+
+from core.pipeline import DataUploadPipeline
+from core.vectordb.postgres4langchain import Postgres
+from core.vectordb import VectordbInterface
+from core.embedding.sentence_transformers import SentenceTransformerEmbedding
+import schema
+
+# Initialize the data upload pipeline
+data_stack = DataUploadPipeline(
+    vectordb = Postgres(
+            host_n_port="localhost:5435",
+            collection_name='adotbcollection',
+            user='admin',
+            password="secret",
+            embedding=SentenceTransformerEmbedding() # Set the embedding to local Sentence Transformers
+            # With PGVector, the embedding dimension size is always hard-coded on init, so we have to set it here.
+        )
+    )
+
+# Set the file processor
+data_stack.set_file_processor(schema.FileProcessorType.LANGCHAIN)
+
+# Process input files
+input_files = glob.glob("./data/translationwords/*.md")
+processed_documents = []
+for path in input_files:
+    docs = data_stack.file_processor.process_file(
+        file=path,
+        file_type=schema.FileType.MD,
+        label="TranslationWords",
+        name=f"tw-en-{path.split('/')[-1]}")
+    processed_documents += docs
+
+# Generate embeddings for the processed documents
+data_stack.embedding.get_embeddings(doc_list=processed_documents)
+
+# Add the processed documents to the database
+data_stack.vectordb.add_to_collection(docs=processed_documents)
+
+# Print some information about the data in the database
+cur = data_stack.vectordb.db_conn.cursor()
+cur.execute("SELECT * FROM embeddings")
+rows = cur.fetchall()
+print("First Row meta from DB", str(rows[0])[:80] + '...')
+print("Last Row meta from DB:", str(rows[-1])[:80] + '...')
+print("Total rows: ", len(rows))
+print("Data upload complete.")
+cur.close()

--- a/recipes/postgres_openai_csv_dataupload.py
+++ b/recipes/postgres_openai_csv_dataupload.py
@@ -15,20 +15,22 @@ import sys
 sys.path.append('../app')
 
 from core.pipeline import DataUploadPipeline
+from core.vectordb.postgres4langchain import Postgres
+from core.embedding.openai import OpenAIEmbedding
 import schema
 
 ######## Configure the pipeline's tech stack ############
-data_stack = DataUploadPipeline()
-data_stack.set_embedding(
-    schema.EmbeddingType.OPENAI,
-    api_key=os.getenv('OPENAI_API_KEY'),
-    model='text-embedding-ada-002')
-data_stack.set_vectordb(schema.DatabaseType.POSTGRES,
-    host_n_port="localhost:5435",              # change if your port is different
-    collection_name='aDotBCollection_fromTSV'.lower(), # change if you db name is different
-    user='postgres',
-    password="password")
-
+data_stack = DataUploadPipeline(
+    vectordb=Postgres(
+        host_n_port="localhost:5435",       # change if your port is different
+        collection_name='adotbcollection',  # change if you db name is different
+        user='admin',
+        password="secret",
+        embedding=OpenAIEmbedding(
+            api_key=os.getenv('OPENAI_API_KEY'),
+            model='text-embedding-ada-002')
+        ),   
+)
 
 ######## File Processor #############
 INPUTFILE = "./data/dataupload.tsv"


### PR DESCRIPTION
By adding a local embeddings model, some aspects of our pipeline creation flow were disrupted. Specifically, pgvector hard-codes the embedding dimension size on initialization, which means that you cannot just initialize and then set the embedding type afterwards using `set_embedding()` method. Instead, when initializing a `vectordb` param, you have to do something like this:

```
# Initialize the data upload pipeline
data_stack = DataUploadPipeline(
    vectordb = Postgres(
            host_n_port="localhost:5435",
            collection_name='adotbcollection',
            user='admin',
            password="secret",
-->         embedding=SentenceTransformerEmbedding() # Set the embedding to local Sentence Transformers
            # With PGVector, the embedding dimension size is always hard-coded on init, so we have to set it here.
        )
    )
```

If you do not set the embedding size, it will default to the HUGGINGFACE_DEFAULT embedding class size, which is 384. For OpenAI, you need 1536, so this would not work without being able to specify the embedding size up front. Therefore, I added the following code:

```
class Postgres(VectordbInterface, BaseRetriever): #pylint: disable=too-many-instance-attributes
    '''Interface for vector database technology, its connection, configs and operations'''
   ...
    embedding: EmbeddingInterface = None
    def __init__(self, 
        embedding: EmbeddingInterface = None, 
        ...
        **kwargs) -> None: 
        '''Instantiate a chroma client'''
        # You MUST set embedding with PGVector, since with this DB type the embedding dimension size always hard-coded on init
        if embedding is None:
            raise ValueError("You MUST set embedding with PGVector, since with this DB type the embedding dimension size always hard-coded on init")
        self.embedding = embedding
```

Other vectorstore products like Chroma, LanceDB, etc. are more flexible, so I've simply added this as an idiosyncrasy to the postgres4langchain `Postgres()` class.

I don't really like the idea of just defaulting to our default local Huggingface embedding size, since A) that could change depending on the local model we use and B) it's probably a better dev experience to just throw an error and state the problem transparently for pgvector specifically.