### PR TITLE
Fix openai-vanilla implementation

### DIFF
--- a/app/core/llm_framework/openai_vanilla.py
+++ b/app/core/llm_framework/openai_vanilla.py
@@ -92,7 +92,6 @@ class OpenAIVanilla(LLMFrameworkInterface): #pylint: disable=too-few-public-meth
         query_text = '\n'.join([x[0] + '/n' + x[1][:50] + '\n' for x in chat_history])
         query_text += '\n' + query
         source_documents = self.vectordb.get_relevant_documents(query_text)
-        print(f'{source_documents=}')
         context = get_context(source_documents)
         pre_prompt = get_pre_prompt(context)
         prompt = append_query_to_prompt(pre_prompt, query, chat_history)

--- a/app/core/pipeline/__init__.py
+++ b/app/core/pipeline/__init__.py
@@ -18,6 +18,7 @@ from core.vectordb.chroma import Chroma
 from core.vectordb.chroma4langchain import Chroma as ChromaLC
 from core.vectordb.postgres4langchain import Postgres
 from core.llm_framework.openai_langchain import LangchainOpenAI
+from core.llm_framework.openai_vanilla import OpenAIVanilla
 from core.audio.whisper import WhisperAudioTranscription
 
 #pylint: disable=unused-argument
@@ -131,6 +132,11 @@ class ConversationPipeline(DataUploadPipeline):
                 vectordb = ChromaLC(host=vectordb.db_host, port=vectordb.db_port,
                     path=vectordb.db_path, collection_name=vectordb.collection_name)
             self.llm_framework = LangchainOpenAI(vectordb=vectordb)
+        elif choice == schema.LLMFrameworkType.VANILLA:
+            if isinstance(vectordb, Chroma):
+                vectordb = ChromaLC(host=vectordb.db_host, port=vectordb.db_port,
+                    path=vectordb.db_path, collection_name=vectordb.collection_name)
+            self.llm_framework = OpenAIVanilla(vectordb=vectordb)
 
     def set_transcription_framework(self,
         choice:schema.AudioTranscriptionType,

--- a/app/schema.py
+++ b/app/schema.py
@@ -35,6 +35,7 @@ class DatabaseType(str, Enum):
 class LLMFrameworkType(str, Enum):
     '''Available framework types'''
     LANGCHAIN = "openai-langchain"
+    VANILLA = "openai-vanilla"
 
 class AudioTranscriptionType(str, Enum):
     '''The type fo text-to-speech audio transcription'''


### PR DESCRIPTION
This brings the openai-vanilla implementation up to speed with the openai-langchain one. It should now work.

In order to switch over, we would just need to specify `llmFrameworkType=openai-vanilla` in the UI endpoint, which I haven't done here.