### PR TITLE
28 auto deployment

### DIFF
--- a/.github/workflows/deploy_from_main.yml
+++ b/.github/workflows/deploy_from_main.yml
@@ -2,13 +2,13 @@
 
 name: deploy
 
-on: [push ]
+# on: [push ]
 # Triggers the workflow on push to main branch 
-# on:
-#   push:
-#     branches: [ main ]
-#   # Allows you to run this workflow manually from the Actions tab
-#   workflow_dispatch:
+on:
+  push:
+    branches: [ main ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
   pull-n-deploy:

--- a/.github/workflows/deploy_from_main.yml
+++ b/.github/workflows/deploy_from_main.yml
@@ -26,4 +26,4 @@ jobs:
           cd /home/kavitha/assistant.bible
           git pull origin main
           cd deployment
-          docker compose --env-file .env up --build -d
+          docker compose --env-file .env up --force-recreate --build -d

--- a/.github/workflows/deploy_from_main.yml
+++ b/.github/workflows/deploy_from_main.yml
@@ -1,0 +1,29 @@
+# Workflow to deploy to a DC server via SSH over RSA
+
+name: deploy
+
+on: [push ]
+# Triggers the workflow on push to main branch 
+# on:
+#   push:
+#     branches: [ main ]
+#   # Allows you to run this workflow manually from the Actions tab
+#   workflow_dispatch:
+
+jobs:
+  pull-n-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: executing remote ssh commands using RSA
+      uses: appleboy/ssh-action@master
+      with:
+        host: ${{ secrets.BCS_DO_HOST }}
+        username: ${{ secrets.BCS_DO_USERNAME }}
+        key: ${{ secrets.BCS_DO_SSH_KEY }}
+        port: 22
+        script_stop: true
+        script: |
+          cd /home/kavitha/assistant.bible
+          git pull origin main
+          cd deployment
+          docker compose --env-file .env up --build -d


### PR DESCRIPTION
CI CD for auto deployment
- Adds a new gitactions workflow
- Automatically deploy to a DO server (current beta.assistant.bible and assistant.bible point to this server)
- Action will be triggered upon push to `main` branch
- Additional actions required. Need to store some secrets in the repository by Admin
-  Closes #28 