### PR TITLE
Set the backup service in docker compose to restart

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -98,6 +98,7 @@ services:
     depends_on:
       - postgresvectordb
     command: daemon --docker
+    restart: always
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - postgres-db-backup:/var/backups:ro


### PR DESCRIPTION
While working on the server, noticed that all other services were set to restart and was up even after system reboot, except the backup service. So adding `restart:always` to the service.