### PR TITLE
Add Reset Conversation button

### DIFF
--- a/app/routers.py
+++ b/app/routers.py
@@ -1,5 +1,6 @@
 '''API endpoint definitions'''
 import os
+import json
 from typing import List
 from fastapi import (
                     APIRouter,
@@ -190,9 +191,19 @@ async def websocket_chat_endpoint(websocket: WebSocket,
             # Receive and send back the client message
             received_bytes = await websocket.receive_bytes()
             try:  # Try treating the bytes as text
-                received_question = received_bytes.decode('utf-8')
+                received_json = received_bytes.decode('utf-8')
+                received_dict = json.loads(received_json)
                 log.info("Text received")
-                question = received_question
+                if received_dict.get("type") == "reset":
+                    chat_stack.chat_history = []
+                    await websocket.send_json({
+                        'sender': 'Bot',
+                        'message': "Let's start a new conversation! What's your question?",
+                        'sources': [],
+                    })
+                    question = ''
+                else:
+                    question = received_dict.get('message')
             except UnicodeDecodeError:  # If that fails, treat it as audio
                 log.info("Audio file received")
                 question = chat_stack.transcription_framework.transcribe_audio(received_bytes)
@@ -202,24 +213,20 @@ async def websocket_chat_endpoint(websocket: WebSocket,
                     media=[])
                 await websocket.send_json(start_human_q.dict())
 
-            # # send back the response
-            # resp = schema.BotResponse(sender=schema.SenderType.USER,
-            #     message=question, type=schema.ChatResponseType.QUESTION)
-            # await websocket.send_json(resp.dict())
+            if len(question) > 0:
+                bot_response = chat_stack.llm_framework.generate_text(
+                                query=question, chat_history=chat_stack.chat_history)
+                log.debug(f"Human: {question}\nBot:{bot_response['answer']}\n"+\
+                    "Sources:"+\
+                    f"{[item.metadata['source'] for item in bot_response['source_documents']]}\n\n")
+                chat_stack.chat_history.append((bot_response['question'], bot_response['answer']))
 
-            bot_response = chat_stack.llm_framework.generate_text(
-                            query=question, chat_history=chat_stack.chat_history)
-            log.debug(f"Human: {question}\nBot:{bot_response['answer']}\n"+\
-                "Sources:"+\
-                f"{[item.metadata['source'] for item in bot_response['source_documents']]}\n\n")
-            chat_stack.chat_history.append((bot_response['question'], bot_response['answer']))
-
-            # Construct a response
-            start_resp = schema.BotResponse(sender=schema.SenderType.BOT,
-                    message=bot_response['answer'], type=schema.ChatResponseType.ANSWER,
-                    sources=[item.metadata['source'] for item in bot_response['source_documents']],
-                    media=[])
-            await websocket.send_json(start_resp.dict())
+                # Construct a response
+                start_resp = schema.BotResponse(sender=schema.SenderType.BOT,
+                        message=bot_response['answer'], type=schema.ChatResponseType.ANSWER,
+                        sources=[item.metadata['source'] for item in bot_response['source_documents']],
+                        media=[])
+                await websocket.send_json(start_resp.dict())
 
         except WebSocketDisconnect:
             if isinstance(chat_stack.vectordb, Chroma):

--- a/app/templates/chat-demo-postgres.html
+++ b/app/templates/chat-demo-postgres.html
@@ -94,7 +94,11 @@
               <i class="fas fa-circle fa-sm"></i> Record
           </button>
         </form>
+        <button class="bg-blue-500 text-white px-4 py-2 rounded mt-3" id="resetButton">
+            Reset Conversation
+          </button>
       </div>
+
     </main>
     <script src="//code.jquery.com/jquery-1.11.1.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/socket.io/4.3.2/socket.io.min.js"></script>
@@ -143,14 +147,32 @@
         if (ws.readyState == WebSocket.CLOSED || ws.readyState == WebSocket.CLOSING){
           window.location.replace({{ site_url }}+'/login');
         }
+        const jsonMessage = JSON.stringify({
+            type: 'message',
+            message: $('#message').val()
+        });
         const encoder = new TextEncoder();
-        const encodedText = encoder.encode($('#message').val());
+        const encodedJson = encoder.encode(jsonMessage);
 
-        ws.send(encodedText);
+        ws.send(encodedJson);
         $('#messages').append('<div class="font-bold">You:</div><div>' + $('#message').val() + '</div>');
         $('#message').val('').focus();
           };
         });
+
+        document.getElementById('resetButton').addEventListener("click", function(event) {
+            console.log("Resetting conversation");
+            var messagesDiv = document.getElementById("messages");
+            messagesDiv.innerHTML = "";
+            var messageInput = document.getElementById("message");
+            messageInput.focus();
+            const jsonMessage = JSON.stringify({
+                type: 'reset'
+              });
+                const encoder = new TextEncoder();
+                const encodedJson = encoder.encode(jsonMessage);
+              ws.send(encodedJson);  // Emit a reset event to the server
+            });
 
         function changeLabel(src) {
             let labels = [];


### PR DESCRIPTION
This adds a Reset Conversation button.

The client-side code then removes all the messages in the page. It then emits an encoded json string (rather than just an encoded message). If that json string contains a key `type` which is `reset` then the server returns a start of conversation message.