### PR TITLE
74 UI gets redirected to nan

### DIFF
--- a/app/core/auth/__init__.py
+++ b/app/core/auth/__init__.py
@@ -55,13 +55,14 @@ def chatbot_auth_check_decorator(func):
         # Verify the access token using Supabase secret
         try:
             supa.auth.get_user(access_token_str)
+
         except gotrue.errors.AuthApiError as e:
             await websocket.accept()
             json_response = schema.BotResponse(sender=schema.SenderType.BOT,
                     message='Please sign in first. I look forward to answering your questions.', type=schema.ChatResponseType.ANSWER,
                     sources=[],
                     media=[])
-            await websocket.send_json(json_response.dict())
+            await websocket.send_json({'logged_in': False, **json_response.dict()})
             return
         return await func(websocket, *args, **kwargs)
 

--- a/app/templates/chat-demo-postgres.html
+++ b/app/templates/chat-demo-postgres.html
@@ -75,6 +75,7 @@
       </div>
       <div class="mt-8">
         <div class="bg-gray-200 p-4 rounded" id="messages"></div>
+        <div class="text-red-500 mt-2" id="errorDiv"></div>
         <form class="flex mt-4">
           <input
             type="text"
@@ -126,6 +127,10 @@
             if(data.type == "error"){
             alert(data.message);
             } else {
+                if(data.logged_in == false) {
+            document.querySelector('#login').style.display = 'block';
+            document.querySelector('#logout').style.display = 'none';
+                }
             let sourcesButton = '';
             if(data.sources.length > 1) {
                 sourcesButton = '&nbsp(<button class="btn btn-link text-blue-500" onclick="alert(\''+data.sources+'\');">sources</button>)';
@@ -137,20 +142,23 @@
         }   
         ws = setupWebsocket(endpoint);
       
-      $('form').submit(function(event) {
-        event.preventDefault();
-        if (event.originalEvent.submitter.id === 'sendButton') {
-        if (ws.readyState == WebSocket.CLOSED || ws.readyState == WebSocket.CLOSING){
-          window.location.replace({{ site_url }}+'/login');
-        }
-        const encoder = new TextEncoder();
-        const encodedText = encoder.encode($('#message').val());
-
-        ws.send(encodedText);
-        $('#messages').append('<div class="font-bold">You:</div><div>' + $('#message').val() + '</div>');
-        $('#message').val('').focus();
-          };
+        $('form').submit(function(event) {
+            event.preventDefault();
+            if (event.originalEvent.submitter.id === 'sendButton') {
+                if (ws.readyState === WebSocket.OPEN) { // Check if WebSocket is open
+                    const encoder = new TextEncoder();
+                    const encodedText = encoder.encode($('#message').val());
+                    ws.send(encodedText);
+                    $('#messages').append('<div class="font-bold">You:</div><div>' + $('#message').val() + '</div>');
+                    $('#message').val('').focus();
+                    $('#errorDiv').empty();
+                } else {
+                    $('#errorDiv').text('Please sign in first, then ask your question.');
+                    console.log('WebSocket is not open');
+                }
+            }
         });
+
 
         function changeLabel(src) {
             let labels = [];
@@ -198,7 +206,8 @@
           navigator.mediaDevices.getUserMedia({ audio: true })
             .then(function (stream) {
                 const recordButton = document.getElementById("recordButton");
-                  if (isRecording) {
+                if (ws.readyState === WebSocket.OPEN) {
+                    if (isRecording) {
                     // If already recording, stop the recording
                     mediaRecorder.stop();
                     recordButton.innerHTML = '<i class="fas fa-circle fa-sm"></i> Record';
@@ -209,6 +218,11 @@
                   }
                   // Toggle the recording state
                   isRecording = !isRecording;
+                } else {
+                    $('#errorDiv').text('Please sign in first, then ask your question.');
+                    console.log('WebSocket is not open');
+                }
+ 
                 })
                 .catch(function (error) {
                   console.error("Error accessing microphone:", error);


### PR DESCRIPTION
Now:

* When the `chatbot_auth_check_decorator` first runs, if the user has an access token, but this doesn't log them in (e.g. it has expired), it will add `logged_in: False` to the returned json.
* The UI will then switch the "Log out" button back to a "Log in" button.
* If the web socket is closed, and the user tries to submit a message, instead of sending the message (and going to the `NaN` page), it will now display an error message telling the user to log in.