### PR TITLE
Database import and query fixes

### DIFF
--- a/app/core/file_processor/langchain_loader.py
+++ b/app/core/file_processor/langchain_loader.py
@@ -46,7 +46,7 @@ class LangchainLoader(FileProcessorInterface):
                  label:str,
                  name: str = None,
                  metadata: dict = None) -> List[schema.Document]:
-        '''Uses langchain's CharacterTextSplitter to convert text contents into document format'''
+        '''Uses langchain's TokenTextSplitter to convert text contents into document format'''
         output_list = []
         loader = TextLoader(file)
         texts = loader.load()

--- a/app/core/file_processor/langchain_loader.py
+++ b/app/core/file_processor/langchain_loader.py
@@ -50,7 +50,7 @@ class LangchainLoader(FileProcessorInterface):
         output_list = []
         loader = TextLoader(file)
         texts = loader.load()
-        text_splitter = TokenTextSplitter(chunk_size=1000, chunk_overlap=200)
+        text_splitter = TokenTextSplitter(chunk_size=1000, chunk_overlap=50)
         text_splits = text_splitter.split_documents(texts)
 
         if not label:

--- a/app/core/file_processor/langchain_loader.py
+++ b/app/core/file_processor/langchain_loader.py
@@ -1,7 +1,7 @@
 '''Langchain based implementation for file handling'''
 from io import TextIOWrapper
 from typing import List
-from langchain.text_splitter import CharacterTextSplitter
+from langchain.text_splitter import TokenTextSplitter
 from langchain.document_loaders import TextLoader
 
 from core.file_processor import FileProcessorInterface
@@ -50,7 +50,7 @@ class LangchainLoader(FileProcessorInterface):
         output_list = []
         loader = TextLoader(file)
         texts = loader.load()
-        text_splitter = CharacterTextSplitter(chunk_size=1000, chunk_overlap=0)
+        text_splitter = TokenTextSplitter(chunk_size=1000, chunk_overlap=200)
         text_splits = text_splitter.split_documents(texts)
 
         if not label:

--- a/app/core/llm_framework/openai_vanilla.py
+++ b/app/core/llm_framework/openai_vanilla.py
@@ -16,7 +16,7 @@ def get_context(source_documents):
     context = '['
     # ** This will need to be adjusted, based on what the returned results look like **
     for i in range(len(source_documents)):
-        if len(source_documents[i].page_content) + len(context) > 14000:  # Maybe 3,500 tokens? Ideally we would estimate this based on tokens
+        if len(source_documents[i].page_content) + len(context) > 14000:  # FIXME: use tiktoken library to count tokens
             break
         context += '{source:' + source_documents[i].metadata.get('source', '')
         context += ', text: ' + source_documents[i].page_content + '}' + ','

--- a/app/core/llm_framework/openai_vanilla.py
+++ b/app/core/llm_framework/openai_vanilla.py
@@ -16,6 +16,8 @@ def get_context(source_documents):
     context = '['
     # ** This will need to be adjusted, based on what the returned results look like **
     for i in range(len(source_documents)):
+        if len(source_documents[i].page_content) + len(context) > 14000:  # Maybe 3,500 tokens? Ideally we would estimate this based on tokens
+            break
         context += '{source:' + source_documents[i].metadata.get('source', '')
         context += ', text: ' + source_documents[i].page_content + '}' + ','
     context += ']' + '\n'
@@ -47,8 +49,8 @@ def get_pre_prompt(context):
 def append_query_to_prompt(prompt, query, chat_history):
     '''Appends the provided query and chat history to the given prompt.'''
     if len(chat_history) > 0:
-        if len(chat_history) > 3:
-            chat_history = chat_history[-3:]
+        if len(chat_history) > 15:
+            chat_history = chat_history[-15:]
         for exchange in chat_history:
             prompt += "\nHuman: " + exchange[0] + "\nAI: " + exchange[1]
     prompt += "\nHuman: " + query + "\nAI: "

--- a/app/core/llm_framework/openai_vanilla.py
+++ b/app/core/llm_framework/openai_vanilla.py
@@ -16,7 +16,7 @@ def get_context(source_documents):
     context = '['
     # ** This will need to be adjusted, based on what the returned results look like **
     for i in range(len(source_documents)):
-        if len(source_documents[i].page_content) + len(context) > 14000:  # FIXME: use tiktoken library to count tokens
+        if len(source_documents[i].page_content) + len(context) > 11000:  # FIXME: use tiktoken library to count tokens
             break
         context += '{source:' + source_documents[i].metadata.get('source', '')
         context += ', text: ' + source_documents[i].page_content + '}' + ','

--- a/app/core/llm_framework/openai_vanilla.py
+++ b/app/core/llm_framework/openai_vanilla.py
@@ -50,7 +50,7 @@ def append_query_to_prompt(prompt, query, chat_history):
     '''Appends the provided query and chat history to the given prompt.'''
     if len(chat_history) > 0:
         if len(chat_history) > 15:
-            chat_history = chat_history[-15:]
+            chat_history = chat_history[-15:] # FIXME: use tiktoken library to check overall token count and ensure context window is not exceeded
         for exchange in chat_history:
             prompt += "\nHuman: " + exchange[0] + "\nAI: " + exchange[1]
     prompt += "\nHuman: " + query + "\nAI: "

--- a/app/core/vectordb/postgres4langchain.py
+++ b/app/core/vectordb/postgres4langchain.py
@@ -171,8 +171,8 @@ class Postgres(VectordbInterface, BaseRetriever): #pylint: disable=too-many-inst
             cur = self.db_conn.cursor()
             cur.execute(
                 "SELECT source_id, document FROM embeddings "+\
-                "where label = ANY(%s) and embedding <=> %s < %s LIMIT %s;",
-                (self.labels, np.array(query_vector), self.max_cosine_distance ,self.query_limit))
+                "WHERE label = ANY(%s) and embedding <=> %s < %s ORDER BY embedding <=> %s LIMIT %s;",
+                (self.labels, np.array(query_vector), self.max_cosine_distance, np.array(query_vector), self.query_limit))
             records = cur.fetchall()
 
             cur.close()

--- a/app/core/vectordb/postgres4langchain.py
+++ b/app/core/vectordb/postgres4langchain.py
@@ -147,8 +147,8 @@ class Postgres(VectordbInterface, BaseRetriever): #pylint: disable=too-many-inst
             cur = self.db_conn.cursor()
             cur.execute(
                 "SELECT source_id, document FROM embeddings "+\
-                "where label = ANY(%s) and embedding <=> %s < %s LIMIT %s;",
-                (self.labels, np.array(query_vector), self.max_cosine_distance, self.query_limit))
+                "WHERE label = ANY(%s) and embedding <=> %s < %s ORDER BY embedding <=> %s LIMIT %s;",
+                (self.labels, np.array(query_vector), self.max_cosine_distance, np.array(query_vector), self.query_limit))
             records = cur.fetchall()
             cur.close()
         except Exception as exe:
@@ -174,6 +174,7 @@ class Postgres(VectordbInterface, BaseRetriever): #pylint: disable=too-many-inst
                 "where label = ANY(%s) and embedding <=> %s < %s LIMIT %s;",
                 (self.labels, np.array(query_vector), self.max_cosine_distance ,self.query_limit))
             records = cur.fetchall()
+
             cur.close()
         except Exception as exe:
             log.exception(exe)


### PR DESCRIPTION
I have:
- Used LangChain's `TokenTextSplitter` instead of `CharacterTextSplitter` to chunk documents. This works as needed for large documents, whereas `CharacterTextSplitter` goes well over the set chunk size. Also added `chunk_overlap=200` which I think should give better performance.
- When querying the database, order the results by cosine similarity, so we get the best results first.
- In `openai_vanilla.py` limit the context to 14,000 characters (around 3,500 English tokens). So that when it's combined with the rest of the prompt, it should still be under 4,096 tokens. Ideally we would have a more exact way of ensuring we're within the token limit, but I think this should work for now. I'll add that as an issue.