### PR TITLE
Test using mock

### DIFF
--- a/.github/workflows/check_on_push.yml
+++ b/.github/workflows/check_on_push.yml
@@ -48,4 +48,4 @@ jobs:
             set SUPABASE_URL=dummy-value
             set SUPABASE_KEY=dummy-value
             set SUPABASE_JWT_SECRET=dummy-value
-            python3 -m pytest tests/test_basics.py test/tests_dataupload.py
+            python3 -m pytest tests/test_basics.py test/tests_dataupload.py --show-capture=no

--- a/.github/workflows/check_on_push.yml
+++ b/.github/workflows/check_on_push.yml
@@ -39,8 +39,8 @@ jobs:
         run: pip3 install -r requirements.txt
 
       - name: start pgvector docker
-        run: docker run -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=secret -e POSTGRES_DB=adotbcollection -p 5432:5432 ankane/pgvector -d
+        run: docker run -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=secret -e POSTGRES_DB=adotbcollection -p 5432:5432 --detach ankane/pgvector 
         
       - name: Run Pytest
         working-directory: ./app
-        run: python3 -m pytest tests/test_basics.py test/tests_dataupload.py -s
+        run: python3 -m pytest -s tests/test_basics.py test/tests_dataupload.py

--- a/.github/workflows/check_on_push.yml
+++ b/.github/workflows/check_on_push.yml
@@ -37,7 +37,15 @@ jobs:
 
       - name: install packages
         run: pip3 install -r requirements.txt
+
+      - name: start pgvector docker
+        run: docker run -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=secret -e POSTGRES_DB=adotbcollection -p 5432:5432 ankane/pgvector
         
       - name: Run Pytest
         working-directory: ./app
-        run: python3 -m pytest tests/test_basics.py test/tests_dataupload.py
+        run: |
+            set OPENAI_API_KEY=dummy-value
+            set SUPABASE_URL=dummy-value
+            set SUPABASE_KEY=dummy-value
+            set SUPABASE_JWT_SECRET=dummy-value
+            python3 -m pytest tests/test_basics.py test/tests_dataupload.py

--- a/.github/workflows/check_on_push.yml
+++ b/.github/workflows/check_on_push.yml
@@ -24,20 +24,20 @@ jobs:
       - name: Run linter
         run: pylint --rcfile=.pylintrc app/*.py app/tests/*.py app/core/*/*.py
 
-  # build-n-test:
-  #   runs-on: ubuntu-latest
+  build-n-test:
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-python@v2
-  #       with:
-  #           python-version: '3.10.6' # Version range or exact version
-  #           architecture: 'x64' # optional x64 or x86.
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+            python-version: '3.10.6' # Version range or exact version
+            architecture: 'x64' # optional x64 or x86.
 
-  #     - name: install packages
-  #       run: pip3 install -r requirements.txt
+      - name: install packages
+        run: pip3 install -r requirements.txt
         
-  #     - name: Run Pytest
-  #       working-directory: ./app
-  #       run: python3 -m pytest tests/test_basics.py
+      - name: Run Pytest
+        working-directory: ./app
+        run: python3 -m pytest tests/test_basics.py test/tests_dataupload.py

--- a/.github/workflows/check_on_push.yml
+++ b/.github/workflows/check_on_push.yml
@@ -39,13 +39,8 @@ jobs:
         run: pip3 install -r requirements.txt
 
       - name: start pgvector docker
-        run: docker run -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=secret -e POSTGRES_DB=adotbcollection -p 5432:5432 ankane/pgvector
+        run: docker run -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=secret -e POSTGRES_DB=adotbcollection -p 5432:5432 ankane/pgvector -d
         
       - name: Run Pytest
         working-directory: ./app
-        run: |
-            set OPENAI_API_KEY=dummy-value
-            set SUPABASE_URL=dummy-value
-            set SUPABASE_KEY=dummy-value
-            set SUPABASE_JWT_SECRET=dummy-value
-            python3 -m pytest tests/test_basics.py test/tests_dataupload.py --show-capture=no
+        run: python3 -m pytest tests/test_basics.py test/tests_dataupload.py -s

--- a/.github/workflows/check_on_push.yml
+++ b/.github/workflows/check_on_push.yml
@@ -43,4 +43,4 @@ jobs:
         
       - name: Run Pytest
         working-directory: ./app
-        run: python3 -m pytest -s tests/test_basics.py test/tests_dataupload.py
+        run: python3 -m pytest -s tests/test_basics.py tests/test_dataupload.py

--- a/app/core/auth/__init__.py
+++ b/app/core/auth/__init__.py
@@ -40,7 +40,7 @@ class AuthInterface:
             if not access_token:
                 raise ValueError("Access token is missing")
             user_data = self.check_token(access_token)
-            if not self.check_role(user_data['user']['id'], 'admin'):
+            if not self.check_role(user_data['user_id'], 'admin'):
                 raise PermissionException("Unauthorized access. User is not admin.")
             return await func(*args, **kwargs)
 
@@ -99,8 +99,8 @@ class AuthInterface:
                     log.exception(exe)
                     db_labels = []
                 else:
-                    db_labels = self.get_accessible_labels(user_data['user']['id'])
-                    log.info(f'{db_labels=}')
+                    db_labels = self.get_accessible_labels(user_data['user_id'])
+                    log.info(f'Accessible labels for the user: {db_labels=}')
 
             kwargs['labels'] = [label for label in kwargs['labels'] if label in db_labels]
             # Proceed with the original function call and pass the sources to it

--- a/app/core/auth/__init__.py
+++ b/app/core/auth/__init__.py
@@ -1,101 +1,109 @@
 '''Functions for Authentication for the Apps'''
 import os
 from functools import wraps
-from custom_exceptions import PermissionException
-import gotrue.errors
+from custom_exceptions import PermissionException, SupabaseException
 from fastapi import WebSocket
 
-from core.auth.supabase import supa
 from log_configs import log
 import schema
 
+#pylint: disable=too-few-public-methods, unused-argument
 
-def admin_auth_check_decorator(func):
-    '''For all data managment APIs'''
-    @wraps(func)
-    async def wrapper(*args, **kwargs):
-        # Extract the access token from the request headers
-        access_token = kwargs.get('token')
-        if not access_token:
-            raise ValueError("Access token is missing")
-        access_token_str = access_token.get_secret_value()
-        # Verify the access token using Supabase secret
-        try:
-            user_data = supa.auth.get_user(access_token_str)
+class AuthInterface:
+    '''Common methods and signatures for user authentication and access management'''
+    def __init__(self):
+        '''Connects to 3rd party auth service or respective implemenation'''
+        # pass
 
-        except gotrue.errors.AuthApiError as e:
-            raise PermissionException("Unauthorized access. Invalid token.") from e
-        else:
-            result = supa.table('adminUsers').select('''
-                    user_id
-                    '''
-                ).eq(
-                'user_id', user_data.user.id
-                ).execute()
-        if not result.data:
-            raise PermissionException("Unauthorized access. User is not admin.")
+    def check_token(self,token:str) -> dict:
+        '''Decodes the token to get the user id'''
+        # To be implemented by the implementing class
+        # if adding more implemenations need to define the output object structure with a schema
+        return {}
 
-        return await func(*args, **kwargs)
+    def check_role(self, user_id, role) -> bool:
+        '''Check if the user has given role'''
+        # To be implemented by the implementing class
+        return False
 
-    return wrapper
+    def get_accessible_labels(self, user_id) -> [str]:
+        '''Check user rights and find document labels he can access'''
+        # To be implemented by the implementing class
+        return []
 
+    def admin_auth_check_decorator(self, func):
+        '''For all data managment APIs'''
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            # Extract the access token from the request headers
+            access_token = kwargs.get('token')
+            if not access_token:
+                raise ValueError("Access token is missing")
+            user_data = self.check_token(access_token)
+            if not self.check_role(user_data['user']['id'], 'admin'):
+                raise PermissionException("Unauthorized access. User is not admin.")
+            return await func(*args, **kwargs)
 
-def chatbot_auth_check_decorator(func):
-    '''checks a predefined token in request header, and checks it is a
-    valid, logged in, user.
-    '''
-    @wraps(func)
-    async def wrapper(websocket: WebSocket, *args, **kwargs):
-        # Extract the access token from the request headers
-        access_token = kwargs.get('token')
-        if not access_token:
-            raise ValueError("Access token is missing")
-        access_token_str = access_token.get_secret_value()
-
-        # Verify the access token using Supabase secret
-        try:
-            supa.auth.get_user(access_token_str)
-
-        except gotrue.errors.AuthApiError as e:
-            await websocket.accept()
-            json_response = schema.BotResponse(sender=schema.SenderType.BOT,
-                    message='Please sign in first. I look forward to answering your questions.', type=schema.ChatResponseType.ANSWER,
-                    sources=[],
-                    media=[])
-            await websocket.send_json({'logged_in': False, **json_response.dict()})
-            return
-        return await func(websocket, *args, **kwargs)
-
-    return wrapper
+        return wrapper
 
 
-def chatbot_get_labels_decorator(func):
-    '''checks a predefined token in request header, and returns available sources.
-    '''
-    @wraps(func)
-    async def wrapper(*args, **kwargs):
-        # Extract the access token from the request headers
-        access_token = kwargs.get('token')
-        if not access_token:
-            db_labels = []
-        else:
-            access_token_str = access_token.get_secret_value()
-
-            # Verify the access token using Supabase secret
+    def chatbot_auth_check_decorator(self, func):
+        '''checks a predefined token in request header, and checks it is a
+        valid, logged in, user.
+        '''
+        @wraps(func)
+        async def wrapper(websocket: WebSocket, *args, **kwargs):
+            # Extract the access token from the request headers
+            access_token = kwargs.get('token')
+            if not access_token:
+                raise ValueError("Access token is missing")
             try:
-                user_data = supa.auth.get_user(access_token_str)
+                self.check_token(access_token)
+            except PermissionException:
+                await websocket.accept()
+                json_response = schema.BotResponse(sender=schema.SenderType.BOT,
+                        message='Please sign in first. I look forward to answering your questions.',
+                        type=schema.ChatResponseType.ANSWER,
+                        sources=[],
+                        media=[])
+                await websocket.send_json({'logged_in': False, **json_response.dict()})
+                return
+            except Exception as exe: #pylint: disable=broad-exception-caught
+                log.exception(exe)
+                await websocket.accept()
+                json_response = schema.BotResponse(sender=schema.SenderType.BOT,
+                        message='Error in Authentication:'+str(exe),
+                        type=schema.ChatResponseType.ANSWER,
+                        sources=[],
+                        media=[])
+                await websocket.send_json({'logged_in': False, **json_response.dict()})
+                return
+            return await func(websocket, *args, **kwargs)
 
-            except gotrue.errors.AuthApiError as e: # The user is not logged in
+        return wrapper
+
+
+    def chatbot_get_labels_decorator(self, func):
+        '''checks a predefined token in request header, and returns available sources.
+        '''
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            # Extract the access token from the request headers
+            access_token = kwargs.get('token')
+            if not access_token:
                 db_labels = []
-
             else:
-                result = supa.table('userAttributes').select('id, user_id, user_type, "userTypes"(user_type, sources)').eq('user_id', user_data.user.id).execute()
-                db_labels = []
-                for data in result.data:
-                    db_labels.extend(data.get('userTypes', {}).get('sources', []))
-                log.info(f'{db_labels=}')
-        kwargs['labels'] = [label for label in kwargs['labels'] if label in db_labels]
-        # Proceed with the original function call and pass the sources to it
-        return await func(*args, **kwargs)
+                try:
+                    user_data = self.check_token(access_token)
+                except Exception as exe: #pylint: disable=broad-exception-caught
+                    log.exception(exe)
+                    db_labels = []
+                else:
+                    db_labels = self.get_accessible_labels(user_data['user']['id'])
+                    log.info(f'{db_labels=}')
 
-    return wrapper
+            kwargs['labels'] = [label for label in kwargs['labels'] if label in db_labels]
+            # Proceed with the original function call and pass the sources to it
+            return await func(*args, **kwargs)
+
+        return wrapper

--- a/app/core/auth/supabase.py
+++ b/app/core/auth/supabase.py
@@ -6,12 +6,14 @@ from core.auth import AuthInterface
 from custom_exceptions import SupabaseException, GenericException, PermissionException
 from log_configs import log
 
+#pylint: disable=fixme
 class Supabase(AuthInterface):
     '''The supabase implementation of the auth interface'''
     def __init__(self,
                 url=os.environ.get("SUPABASE_URL"),
                 key=os.environ.get("SUPABASE_KEY")):
         '''Connect to Supabase server'''
+        # FIXME : Ideal to be able to mock the __init__ from tests
         if url is None or key is None:
             self.conn = None
         else:

--- a/app/core/auth/supabase.py
+++ b/app/core/auth/supabase.py
@@ -47,7 +47,7 @@ class Supabase(AuthInterface):
         return False
 
     def get_accessible_labels(self, user_id):
-        '''Queries the supabase table to bet user-source mapping'''
+        '''Queries the supabase table to get user-source mapping'''
         try:
             result = self.conn.table('userAttributes').select(
                 'id, user_id, user_type, "userTypes"(user_type, sources)').eq(

--- a/app/core/auth/supabase.py
+++ b/app/core/auth/supabase.py
@@ -1,6 +1,50 @@
 import os
 from supabase import create_client, Client
+import gotrue.errors
 
-url: str = os.environ.get("SUPABASE_URL")
-key: str = os.environ.get("SUPABASE_KEY")
-supa: Client = create_client(url, key)
+from core.auth import AuthInterface
+from custom_exceptions import SupabaseException, GenericException, PermissionException
+
+class Supabase(AuthInterface):
+    '''The supabase implementation of the auth interface'''
+    def __init__(self,
+                url=os.environ.get("SUPABASE_URL"),
+                key=os.environ.get("SUPABASE_KEY")):
+        '''Connect to Supabase server'''
+        self.conn = create_client(url, key)
+
+    def check_token(self, access_token):
+        '''Pass on the token from user to supabase and get id'''
+        try:
+            access_token_str = access_token.get_secret_value()
+            # Verify the access token using Supabase secret
+            user_data = self.conn.auth.get_user(access_token_str)
+        except gotrue.errors.AuthApiError as exe:
+            raise PermissionException("Unauthorized access. Invalid token.") from exe
+        except Exception as exe:
+            raise SupabaseException(str(exe)) from exe
+        return user_data.__dict__
+
+    def check_role(self, user_id, role='admin'):
+        '''Check supabase DB tables to see if user is the given role.'''
+        if role != "admin":
+            raise GenericException("Different roles is not supported in Supabase (yet)!!!")
+        result = self.conn.table('adminUsers').select('''
+                        user_id
+                        '''
+                    ).eq(
+                    'user_id', user_id
+                    ).execute()
+        if result:
+            return True
+        return False
+
+    def get_accessible_labels(self, user_id):
+        '''Queries the supabase table to bet user-source mapping'''
+        result = self.conn.table('userAttributes').select(
+            'id, user_id, user_type, "userTypes"(user_type, sources)').eq(
+            'user_id', user_id).execute()
+        db_labels = []
+        for data in result.data:
+            db_labels.extend(data.get('userTypes', {}).get('sources', []))
+        return db_labels

--- a/app/core/auth/supabase.py
+++ b/app/core/auth/supabase.py
@@ -4,6 +4,7 @@ import gotrue.errors
 
 from core.auth import AuthInterface
 from custom_exceptions import SupabaseException, GenericException, PermissionException
+from log_configs import log
 
 class Supabase(AuthInterface):
     '''The supabase implementation of the auth interface'''
@@ -21,7 +22,7 @@ class Supabase(AuthInterface):
             user_data = self.conn.auth.get_user(access_token_str)
         except gotrue.errors.AuthApiError as exe:
             raise PermissionException("Unauthorized access. Invalid token.") from exe
-        except Exception as exe:
+        except Exception as exe: #pylint: disable=broad-exception-caught
             raise SupabaseException(str(exe)) from exe
         return {"user_id": user_data.user.id, "user_roles":[], "user_name":""}
 
@@ -29,21 +30,27 @@ class Supabase(AuthInterface):
         '''Check supabase DB tables to see if user is the given role.'''
         if role != "admin":
             raise GenericException("Different roles is not supported in Supabase (yet)!!!")
-        result = self.conn.table('adminUsers').select('''
-                        user_id
-                        '''
-                    ).eq(
-                    'user_id', user_id
-                    ).execute()
+        try:
+            result = self.conn.table('adminUsers').select('''
+                            user_id
+                            '''
+                        ).eq(
+                        'user_id', user_id
+                        ).execute()
+        except Exception as exe:  #pylint: disable=broad-exception-caught
+            raise SupabaseException(str(exe)) from exe
         if result:
             return True
         return False
 
     def get_accessible_labels(self, user_id):
         '''Queries the supabase table to bet user-source mapping'''
-        result = self.conn.table('userAttributes').select(
-            'id, user_id, user_type, "userTypes"(user_type, sources)').eq(
-            'user_id', user_id).execute()
+        try:
+            result = self.conn.table('userAttributes').select(
+                'id, user_id, user_type, "userTypes"(user_type, sources)').eq(
+                'user_id', user_id).execute()
+        except Exception as exe:
+            raise SupabaseException(str(exe)) from exe
         db_labels = []
         for data in result.data:
             db_labels.extend(data.get('userTypes', {}).get('sources', []))

--- a/app/core/auth/supabase.py
+++ b/app/core/auth/supabase.py
@@ -12,7 +12,10 @@ class Supabase(AuthInterface):
                 url=os.environ.get("SUPABASE_URL"),
                 key=os.environ.get("SUPABASE_KEY")):
         '''Connect to Supabase server'''
-        self.conn = create_client(url, key)
+        if url is None or key is None:
+            self.conn = None
+        else:
+            self.conn = create_client(url, key)
 
     def check_token(self, access_token):
         '''Pass on the token from user to supabase and get id'''

--- a/app/core/auth/supabase.py
+++ b/app/core/auth/supabase.py
@@ -23,7 +23,7 @@ class Supabase(AuthInterface):
             raise PermissionException("Unauthorized access. Invalid token.") from exe
         except Exception as exe:
             raise SupabaseException(str(exe)) from exe
-        return user_data.__dict__
+        return {"user_id": user_data.user.id, "user_roles":[], "user_name":""}
 
     def check_role(self, user_id, role='admin'):
         '''Check supabase DB tables to see if user is the given role.'''

--- a/app/core/llm_framework/openai_langchain.py
+++ b/app/core/llm_framework/openai_langchain.py
@@ -14,7 +14,7 @@ from custom_exceptions import AccessException, OpenAIException, ChatErrorRespons
 from log_configs import log
 
 
-#pylint: disable=too-few-public-methods
+#pylint: disable=too-few-public-methods,fixme
 
 class LangchainOpenAI(LLMFrameworkInterface):
     '''Uses OpenAI APIs to create vectors for text'''
@@ -25,6 +25,7 @@ class LangchainOpenAI(LLMFrameworkInterface):
     chain = None
     vectordb = None
     def __init__(self, #pylint: disable=super-init-not-called
+                # FIXME : Ideal to be able to mock the __init__ from tests
                 key:str=os.getenv("OPENAI_API_KEY","dummy-for-test"),
                 model_name:str = 'gpt-3.5-turbo',
                 vectordb:VectordbInterface = Chroma(),

--- a/app/core/llm_framework/openai_langchain.py
+++ b/app/core/llm_framework/openai_langchain.py
@@ -25,7 +25,7 @@ class LangchainOpenAI(LLMFrameworkInterface):
     chain = None
     vectordb = None
     def __init__(self, #pylint: disable=super-init-not-called
-                key:str=os.getenv("OPENAI_API_KEY"),
+                key:str=os.getenv("OPENAI_API_KEY","dummy-for-test"),
                 model_name:str = 'gpt-3.5-turbo',
                 vectordb:VectordbInterface = Chroma(),
                 max_tokens_limit:int=int(os.getenv("OPENAI_MAX_TOKEN_LIMIT", '3052'))) -> None:

--- a/app/core/llm_framework/openai_langchain.py
+++ b/app/core/llm_framework/openai_langchain.py
@@ -25,7 +25,7 @@ class LangchainOpenAI(LLMFrameworkInterface):
     chain = None
     vectordb = None
     def __init__(self, #pylint: disable=super-init-not-called
-                key:str=os.getenv("OPENAI_API_KEY", "dummy-key-for-open-ai"),
+                key:str=os.getenv("OPENAI_API_KEY"),
                 model_name:str = 'gpt-3.5-turbo',
                 vectordb:VectordbInterface = Chroma(),
                 max_tokens_limit:int=int(os.getenv("OPENAI_MAX_TOKEN_LIMIT", '3052'))) -> None:
@@ -38,7 +38,9 @@ class LangchainOpenAI(LLMFrameworkInterface):
         self.vectordb = vectordb
         self.api_object = ChatOpenAI
         self.api_object.api_key = self.api_key
-        self.llm = self.api_object(temperature=0, model_name=self.model_name)
+        self.llm = self.api_object(temperature=0,
+                                    model_name=self.model_name,
+                                    openai_api_key=self.api_key)
         # memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
 
         self.chain = ConversationalRetrievalChain.from_llm(self.llm,

--- a/app/core/llm_framework/openai_langchain.py
+++ b/app/core/llm_framework/openai_langchain.py
@@ -25,7 +25,7 @@ class LangchainOpenAI(LLMFrameworkInterface):
     chain = None
     vectordb = None
     def __init__(self, #pylint: disable=super-init-not-called
-                key:str=os.getenv("OPENAI_API_KEY"),
+                key:str=os.getenv("OPENAI_API_KEY", "dummy-key-for-open-ai"),
                 model_name:str = 'gpt-3.5-turbo',
                 vectordb:VectordbInterface = Chroma(),
                 max_tokens_limit:int=int(os.getenv("OPENAI_MAX_TOKEN_LIMIT", '3052'))) -> None:

--- a/app/custom_exceptions.py
+++ b/app/custom_exceptions.py
@@ -57,6 +57,14 @@ class PostgresException(Exception):
         self.detail = detail
         self.status_code = 502
 
+class SupabaseException(Exception):
+    '''Format for errors from Supabase'''
+    def __init__(self, detail):
+        super().__init__()
+        self.name = "Error from Supabase Authentication system"
+        self.detail = detail
+        self.status_code = 502
+
 class GenericException(Exception):
     '''Format for Database error'''
     def __init__(self, detail: str):

--- a/app/routers.py
+++ b/app/routers.py
@@ -44,6 +44,8 @@ OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
 
 UPLOAD_PATH = "./uploaded-files/"
 
+#pylint: disable=fixme
+
 auth_service = Supabase()
 
 @router.get("/",
@@ -484,8 +486,8 @@ async def signup(
             "email": email, 
             "password": password,
             })
-    except gotrue.errors.AuthApiError as exe:
-        raise PermissionException("Sign up error") from exe
+    except gotrue.errors.AuthApiError as exce:
+        raise PermissionException("Sign up error") from exce
 
     return {
         "message": "Please check your email to confirm your account.",

--- a/app/routers.py
+++ b/app/routers.py
@@ -231,9 +231,9 @@ async def websocket_chat_endpoint(websocket: WebSocket,
 
                 # Construct a response
                 start_resp = schema.BotResponse(sender=schema.SenderType.BOT,
-                        message=bot_response['answer'], type=schema.ChatResponseType.ANSWER,
-                        sources=[item.metadata['source'] for item in bot_response['source_documents']],
-                        media=[])
+                    message=bot_response['answer'], type=schema.ChatResponseType.ANSWER,
+                    sources=[item.metadata['source'] for item in bot_response['source_documents']],
+                    media=[])
                 await websocket.send_json(start_resp.dict())
         except ChatErrorResponse as exe:
             resp = schema.BotResponse(
@@ -445,14 +445,15 @@ async def login(
     """Signs in a user"""
     try:
         data = auth_service.conn.auth.sign_in_with_password({"email": email, "password": password})
-    except gotrue.errors.AuthApiError as e:
-        log.info(f'We have an error: {e}')
-        print(e)
-        if str(e) == 'Email not confirmed':
+    except gotrue.errors.AuthApiError as exe:
+        log.error(f'We have an error: {exe}')
+        if str(exe) == 'Email not confirmed':
             print("It's an email not confirmed error")
-            raise HTTPException(status_code=401, detail="The user email hasn't been confirmed. Please confirm your email and then try to log in again.")
+            raise HTTPException(status_code=401,
+                detail="The user email hasn't been confirmed. "+\
+                "Please confirm your email and then try to log in again.") from exe
         
-        raise PermissionException("Unauthorized access. Invalid token.") from e
+        raise PermissionException("Unauthorized access. Invalid credentials.") from exe
 
     return {
         "message": "User logged in successfully",

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -3,21 +3,61 @@
 import os
 import shutil
 import pytest
-
+import psycopg2
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 
 @pytest.fixture
 def fresh_db():
-    '''Deletes the chroma db folder if one existed and 
-    returns the DB_config to be used in all APIs'''
+    '''For Chroma: Deletes the chroma test db folder if one existed
+    For Postgres: Drops the test database if one existed
+    Returns: the DB_config to be used for chroma or postgres connection'''
+    collection_name = "adotdcollection_test"
+
+    # Chroma Specific clean up
     chroma_db_path = "chromadb_store_test"
-    chroma_db_collection = "adotdcollection_test"
     if os.path.exists(chroma_db_path):
         shutil.rmtree(chroma_db_path)
+
+    # Postgres specific cleanup
+    pg_db_host = os.environ.get("POSTGRES_DB_HOST", "localhost")
+    pg_db_port = os.environ.get("POSTGRES_DB_PORT", "5432")
+    pg_db_user = os.environ.get("POSTGRES_DB_USER", "admin")
+    pg_db_password=os.environ.get("POSTGRES_DB_PASSWORD", "secret")
+    db_conn = psycopg2.connect(user=pg_db_user, password=pg_db_password,
+                host=pg_db_host, port=pg_db_port, dbname='postgres')
+    db_conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    cur = db_conn.cursor()
+    delete_statement = f"DROP DATABASE IF EXISTS {collection_name}"
+    cur.execute(delete_statement)
+    create_statement = f"CREATE DATABASE {collection_name}"
+    cur.execute(create_statement)
+    cur.close()
+    db_conn.close()
+
     try:
         yield {
                 "dbPath": chroma_db_path,
-                "collectionName": chroma_db_collection
+                "collectionName": collection_name
               }
     finally:
         if os.path.exists(chroma_db_path):
             shutil.rmtree(chroma_db_path)
+        db_conn = psycopg2.connect(user=pg_db_user, password=pg_db_password,
+                host=pg_db_host, port=pg_db_port, dbname='postgres')
+        db_conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+        cur = db_conn.cursor()
+        delete_statement = f"DROP DATABASE IF EXISTS {collection_name}"
+        cur.execute(delete_statement)
+        cur.close()
+        db_conn.close()
+
+@pytest.fixture
+def clear_loggers():
+    """Remove handlers from all loggers due to an issue in chroma(duck-db) module
+    https://github.com/pytest-dev/pytest/issues/5502"""
+    import logging
+    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    for logger in loggers:
+        handlers = getattr(logger, 'handlers', [])
+        for handler in handlers:
+            logger.removeHandler(handler)

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -50,14 +50,3 @@ def fresh_db():
         cur.execute(delete_statement)
         cur.close()
         db_conn.close()
-
-@pytest.fixture
-def clear_loggers():
-    """Remove handlers from all loggers due to an issue in chroma(duck-db) module
-    https://github.com/pytest-dev/pytest/issues/5502"""
-    import logging
-    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
-    for logger in loggers:
-        handlers = getattr(logger, 'handlers', [])
-        for handler in handlers:
-            logger.removeHandler(handler)

--- a/app/tests/test_basics.py
+++ b/app/tests/test_basics.py
@@ -1,4 +1,4 @@
-'''Basic tests to check App is working'''
+'''Basic tests to check App is working and pages are loading'''
 from . import client
 
 def test_test_endpoint():
@@ -14,5 +14,10 @@ def test_index_page_load():
 
 def test_chat_demo_page_load():
     '''test the default API endpoints and check if App is up'''
-    response = client.get("/ui")
+    response = client.get("/app")
+    assert response.status_code == 200
+
+def test_login_page_load():
+    '''test the default API endpoints and check if App is up'''
+    response = client.get("/login")
     assert response.status_code == 200

--- a/app/tests/test_dataupload.py
+++ b/app/tests/test_dataupload.py
@@ -1,8 +1,21 @@
 '''Test connecting to test DB and uploading different types of documents'''
 import os
-from . import client
+import pytest
+from unittest.mock import patch, Mock
+from functools import wraps
 
-admin_token = os.getenv('ADMIN_ACCESS_TOKEN', "chatchatchat")
+from . import client
+from app import schema
+from app import routers
+from app.core.auth.supabase import Supabase
+
+
+# patch('app.routers.auth_service.check_token', return_value={'user':{'id':'1111111111'}}).start()
+# patch('app.routers.auth_service.check_role', return_value=True).start()
+
+
+
+ADMIN_TOKEN = "dummy-admin-token"
 
 SENT_DATA =  [
     {
@@ -41,17 +54,32 @@ MD_FILES = [
 
 CSV_FILE = "../recipes/data/dataupload.tsv"
 
-def test_data_upload_processed_sentences(fresh_db):
+
+
+@pytest.mark.parametrize('vectordb', [schema.DatabaseType.CHROMA, schema.DatabaseType.POSTGRES])
+def test_data_upload_processed_sentences(mocker, vectordb, fresh_db, clear_loggers):
     '''Test uploading documents to the vector DB'''
+    mocker.patch('app.routers.Supabase.check_token',return_value={'user':{'id':'1111'}})
+    mocker.patch('app.routers.Supabase.check_role',return_value=True)
     response = client.post("/upload/sentences",
-                    params={"vectordb_type": "chroma-db", "token":admin_token},
-                    json={"document_objs":SENT_DATA, "vectordb_config": fresh_db}
+                    params={"vectordb_type": vectordb.value,
+                            "token":ADMIN_TOKEN,
+                            "dbPath":fresh_db['dbPath'],
+                            "collectionName":fresh_db['collectionName'],
+                            "embeddingType":schema.EmbeddingType.HUGGINGFACE_DEFAULT.value},
+                    json=SENT_DATA
                     )
-    assert response.status_code == 201
+    assert response.status_code == 201, response.json()
     assert response.json() == {"message": "Documents added to DB"}
 
-def test_data_upload_markdown(fresh_db):
+@pytest.mark.parametrize('vectordb', [schema.DatabaseType.CHROMA, schema.DatabaseType.POSTGRES])
+@pytest.mark.parametrize('chunker', [schema.FileProcessorType.LANGCHAIN,
+    # schema.FileProcessorType.VANILLA
+    ])
+def test_data_upload_markdown(mocker, vectordb, chunker, fresh_db, clear_loggers):
     '''Test uploading documents to the vector DB'''
+    mocker.patch('app.routers.Supabase.check_token',return_value={'user':{'id':'1111'}})
+    mocker.patch('app.routers.Supabase.check_role',return_value=True)
     for md_file in MD_FILES:
         with open(md_file, 'rb') as input_file:
 
@@ -60,42 +88,48 @@ def test_data_upload_markdown(fresh_db):
                                                     input_file, "text/markdown")},
                         params={
                             "label":"translationwords",
-                            "file_processor_type": "Langchain-loaders",
-                            "vectordb_type": "chroma-db",
+                            "file_processor_type": chunker.value,
+                            "vectordb_type": vectordb.value,
                             "dbPath":fresh_db["dbPath"],
                             "collectionName":fresh_db["collectionName"],
-                            "token":admin_token
+                            "token":ADMIN_TOKEN
                             }
                         # json={"vectordb_config": fresh_db}
                         )
-            assert response.status_code == 201
+            assert response.status_code == 201, response.json()
             assert response.json() == {"message": "Documents added to DB"}
 
-def test_data_upload_csv(fresh_db):
+@pytest.mark.parametrize('vectordb', [schema.DatabaseType.CHROMA, schema.DatabaseType.POSTGRES])
+def test_data_upload_csv(mocker, vectordb, fresh_db, clear_loggers):
     '''Test uploading documents to the vector DB'''
+    mocker.patch('app.routers.Supabase.check_token',return_value={'user':{'id':'1111'}})
+    mocker.patch('app.routers.Supabase.check_role',return_value=True)
     with open(CSV_FILE, 'rb') as input_file:
         response = client.post("/upload/csv-file",
                     files={"file_obj": (CSV_FILE.rsplit('/', maxsplit=1)[-1],
                                                 input_file, "text/csv")},
                     params={
                         "col_delimiter":"tab",
-                        "vectordb_type": "chroma-db",
+                        "vectordb_type": vectordb.value,
                         "dbPath":fresh_db["dbPath"],
                         "collectionName":fresh_db["collectionName"],
-                        "token":admin_token
+                        "token":ADMIN_TOKEN
                         },
                     json={"vectordb_config": fresh_db}
                     )
-        assert response.status_code == 201
+        assert response.status_code == 201, response.json()
         assert response.json() == {"message": "Documents added to DB"}
 
-def test_get_lables(fresh_db):
+@pytest.mark.parametrize('vectordb', [schema.DatabaseType.CHROMA, schema.DatabaseType.POSTGRES])
+def test_get_lables(mocker, vectordb, fresh_db, clear_loggers):
     '''Check available labels in the vector db, before and after data upload'''
+    mocker.patch('app.routers.Supabase.check_token',return_value={'user':{'id':'1111'}})
+    mocker.patch('app.routers.Supabase.check_role',return_value=True)
     param_args = {
-                    "db_type": "chroma-db",
+                    "db_type": vectordb.value,
                     "dbPath": fresh_db["dbPath"],
                     "collectionName": fresh_db["collectionName"],
-                    "token":admin_token
+                    "token":ADMIN_TOKEN
                 }
 
     # Before upload
@@ -104,21 +138,22 @@ def test_get_lables(fresh_db):
     assert response.json() == []
 
     # Upload set 1
-    test_data_upload_processed_sentences(fresh_db)
+    test_data_upload_processed_sentences(mocker, vectordb, fresh_db, clear_loggers)
     response = client.get("/source-labels",params=param_args)
     assert response.status_code == 200
     for label in ['NIV bible']:
         assert label in response.json()
 
     # Upload set 2
-    test_data_upload_markdown(fresh_db)
+    test_data_upload_markdown(
+        mocker, vectordb, schema.FileProcessorType.LANGCHAIN, fresh_db, clear_loggers)
     response = client.get("/source-labels",params=param_args)
     assert response.status_code == 200
     for label in ['NIV bible', 'translationwords']:
         assert label in response.json()
 
     # Upload set 3
-    test_data_upload_csv(fresh_db)
+    test_data_upload_csv(mocker, vectordb, fresh_db, clear_loggers)
     response = client.get("/source-labels",params=param_args)
     assert response.status_code == 200
     for label in ['NIV bible', 'translationwords', "ESV-Bible"]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ openai==0.27.6
 Jinja2==3.1.2
 chromadb==0.3.22
 pytest==7.3.1
+pytest-mock==3.11.1
 httpx
 pylint==2.17.4
 langchain==0.0.165


### PR DESCRIPTION
This PR Inlcudes
- Enhancements to some of the existing tests #79 

  - [x] Mock Supabase access to check token and role allowing dummy users to run tests
  - [x] Fixture to clean up postgres test DB after each test
  - [x] Dataupload tests
    - [x]  Run the 3 dataupload API tests on chroma and postgres alike
    - [ ]  Run text data upload with different fileprocessors, Langchain and vanilla (test written. But vanilla option erroring out)
    - [ ]  Run dataupload with different embeddings(Mock the ones that need paid services)
  - [x] Get labels API
    - [x] Test get labels works with changing data and different databases
  - [x]  Run tests automatically on PRs and pushes on github actions
  :warning: More tasks break down added in [issue](https://github.com/BibleNLP/assistant.bible/issues/79)
- Refactor of Auth module codebase to fix #106 
   - Needed to split up the decorator functions to be able to mock them. Along with that did the change to interface-class pattern keeping the existing logics intact. (tested only manually) 