### PR TITLE
Mock supabase server connection

### DIFF
--- a/app/core/auth/supabase.py
+++ b/app/core/auth/supabase.py
@@ -13,11 +13,7 @@ class Supabase(AuthInterface):
                 url=os.environ.get("SUPABASE_URL"),
                 key=os.environ.get("SUPABASE_KEY")):
         '''Connect to Supabase server'''
-        # FIXME : Ideal to be able to mock the __init__ from tests
-        if url is None or key is None:
-            self.conn = None
-        else:
-            self.conn = create_client(url, key)
+        self.conn = create_client(url, key)
 
     def check_token(self, access_token):
         '''Pass on the token from user to supabase and get id'''

--- a/app/tests/__init__.py
+++ b/app/tests/__init__.py
@@ -1,7 +1,10 @@
 '''Initializes a test client'''
-
+from unittest.mock import Mock, patch
 from fastapi.testclient import TestClient
 
-from main import app
+mock = Mock()
+
+with patch('supabase.create_client', mock):
+    from main import app
 
 client = TestClient(app)


### PR DESCRIPTION
- Undo changing supabase init to let app start without key and handle it in tests
- In connection with #110 
- Part of #79 